### PR TITLE
V15: Add maximumpayload bytes settings

### DIFF
--- a/15/umbraco-cms/reference/configuration/cache-settings.md
+++ b/15/umbraco-cms/reference/configuration/cache-settings.md
@@ -4,6 +4,34 @@ description: Information on the Cache settings section
 
 # Cache settings
 
+## HybridCacheOptions
+
+Umbraco's cache is implemented using Microsofts `HybridCache`, which also has its own settings. For more information [see the HybridCache documentation](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-9.0#options).
+
+### MaximumPayLoadBytes
+
+One `HybridCache` setting of particular interest is the `MaximumPayloadBytes` setting. This setting specifies the maximum size of a cache entry in bytes, and replaces the `BTreeBlockSize` setting from NuCache.
+The default from Microsoft is 1MB. However, this limit could quickly be reached, especially if using property editors like the block grid, and multiple languages.
+To try and avoid this Umbraco overrides this setting to 100MB by default, however you can also configure this manually using a composer:
+
+```csharp
+using Microsoft.Extensions.Caching.Hybrid;
+using Umbraco.Cms.Core.Composing;
+
+namespace MySite.Caching;
+
+public class ConfigureCacheComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddOptions<HybridCacheOptions>().Configure(x =>
+        {
+            x.MaximumPayloadBytes = 1024 * 1024 * 10; // 10MB
+        });
+    }
+}
+```
+
 ## Seeding settings
 
 The Seeding settings allow you to specify which content should be seeded into your cache. For more information on cache seeding see the [Cache Seeding.](../cache/cache-seeding.md) article.


### PR DESCRIPTION
## Description

Adds a section about `MaximumPayloadBytes` options, this used to be an Umbraco setting, but is now a Microsoft thing, however since this might be very relevant I've added it to the cache config docs

Note: This extends #6578, however since that PR has already been reviewed I've made this a separate PR that targets the other PR. 

This means that this can be merged into #6578 before RC-3

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS 15

